### PR TITLE
[양서연] /post 페이지 구현

### DIFF
--- a/src/component/common/option/ColorOption.module.css
+++ b/src/component/common/option/ColorOption.module.css
@@ -57,3 +57,17 @@
 .backgroundChecked {
   position: absolute;
 }
+
+@media screen and (min-width: 769px) and (max-width: 1024px) {
+  .backgroundOptions {
+    grid-template-columns: repeat(4, minmax(168px, 200px));
+    max-width: 720px;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .backgroundOptions {
+    grid-template-columns: repeat(2, 168px);
+    max-width: 320px;
+  }
+}

--- a/src/component/common/option/ImageOption.module.css
+++ b/src/component/common/option/ImageOption.module.css
@@ -69,3 +69,17 @@
 .ImgChecked {
   position: absolute;
 }
+
+@media screen and (min-width: 769px) and (max-width: 1024px) {
+  .ImgOptions {
+    grid-template-columns: repeat(4, minmax(168px, 200px));
+    max-width: 720px;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .ImgOptions {
+    grid-template-columns: repeat(2, 168px);
+    max-width: 320px;
+  }
+}

--- a/src/component/pages/Post.jsx
+++ b/src/component/pages/Post.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import styles from "./Post.module.css";
 import Input from "../common/textField/Input/Input";
 import ColorOption from "../common/option/ColorOption";
@@ -34,11 +35,13 @@ function Post() {
         </div>
         {selectedButtonName === BUTTON_NAME[0] && <ColorOption />}
         {selectedButtonName === BUTTON_NAME[1] && <ImageOption />}
-        <div className={styles.createButton}>
+        <Link to='/post/{id}' style={{textDecoration: 'none'}}>
+          <div className={styles.createButton}>
             <Button type="primary" height="tall" disabled={!inputValue}>
-            생성하기
-          </Button>
-        </div>
+              생성하기
+            </Button>
+          </div>
+        </Link>
       </div>
     </div>
   )

--- a/src/component/pages/Post.jsx
+++ b/src/component/pages/Post.jsx
@@ -35,7 +35,7 @@ function Post() {
         {selectedButtonName === BUTTON_NAME[0] && <ColorOption />}
         {selectedButtonName === BUTTON_NAME[1] && <ImageOption />}
         <div className={styles.createButton}>
-          <Button type="primary" height="tall" >
+            <Button type="primary" height="tall" disabled={!inputValue}>
             생성하기
           </Button>
         </div>

--- a/src/component/pages/Post.jsx
+++ b/src/component/pages/Post.jsx
@@ -2,18 +2,23 @@ import { useState } from "react";
 import styles from "./Post.module.css";
 import Input from "../common/textField/Input/Input";
 import ColorOption from "../common/option/ColorOption";
-import Button from "../common/button/Button";
+import ToggleButton from "../common/button/ToggleButton";
+import ImageOption from "../common/option/ImageOption";
+
+const BUTTON_NAME = ['컬러', '이미지']
 
 function Post() {
-  const [inputValue, setInputValue] = useState("")
-
+  const [inputValue, setInputValue] = useState("");
+  const [selectedButtonName, setSelectedButtonName] = useState("컬러");
+;
   const handleInputValue = (value) => setInputValue(value);
+  const handleButtonClick = (e) => setSelectedButtonName(e.target.innerText);
   
   return (
     <div className={styles.container}>
       <div className={styles.content}>
         <div className={styles.inputBox}>
-          <div className={styles.inputName}>To.{inputValue}</div>
+          <div className={styles.inputName}>To. {inputValue}</div>
           <Input inputValue={inputValue} onInputValueChange={handleInputValue}/>
         </div>
 
@@ -22,9 +27,12 @@ function Post() {
           <p className={styles.describeSubtitle}>컬러를 선택하거나, 이미지를 선택할 수 있습니다.</p>
         </div>
         <div className={styles.selectButton}>
-          <Button type="toggle" />
+          <div onClick={handleButtonClick}>
+            <ToggleButton />
+          </div>
         </div>
-        <ColorOption />
+        {selectedButtonName === BUTTON_NAME[0] && <ColorOption />}
+        {selectedButtonName === BUTTON_NAME[1] && <ImageOption />}
       </div>
     </div>
   )

--- a/src/component/pages/Post.jsx
+++ b/src/component/pages/Post.jsx
@@ -4,6 +4,7 @@ import Input from "../common/textField/Input/Input";
 import ColorOption from "../common/option/ColorOption";
 import ToggleButton from "../common/button/ToggleButton";
 import ImageOption from "../common/option/ImageOption";
+import Button from "../common/button/Button";
 
 const BUTTON_NAME = ['컬러', '이미지']
 
@@ -33,6 +34,11 @@ function Post() {
         </div>
         {selectedButtonName === BUTTON_NAME[0] && <ColorOption />}
         {selectedButtonName === BUTTON_NAME[1] && <ImageOption />}
+        <div className={styles.createButton}>
+          <Button type="primary" height="tall" >
+            생성하기
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/src/component/pages/Post.jsx
+++ b/src/component/pages/Post.jsx
@@ -1,5 +1,33 @@
+import { useState } from "react";
+import styles from "./Post.module.css";
+import Input from "../common/textField/Input/Input";
+import ColorOption from "../common/option/ColorOption";
+import Button from "../common/button/Button";
+
 function Post() {
-  return <div>Post</div>;
+  const [inputValue, setInputValue] = useState("")
+
+  const handleInputValue = (value) => setInputValue(value);
+  
+  return (
+    <div className={styles.container}>
+      <div className={styles.content}>
+        <div className={styles.inputBox}>
+          <div className={styles.inputName}>To.{inputValue}</div>
+          <Input inputValue={inputValue} onInputValueChange={handleInputValue}/>
+        </div>
+
+        <div className={styles.describeBackgroundInfo}>
+          <h2 className={styles.describeTitle}>배경화면을 선택해 주세요</h2>
+          <p className={styles.describeSubtitle}>컬러를 선택하거나, 이미지를 선택할 수 있습니다.</p>
+        </div>
+        <div className={styles.selectButton}>
+          <Button type="toggle" />
+        </div>
+        <ColorOption />
+      </div>
+    </div>
+  )
 }
 
 export default Post;

--- a/src/component/pages/Post.module.css
+++ b/src/component/pages/Post.module.css
@@ -42,7 +42,7 @@
 }
 
 .selectButton {
-  padding: 42px 0 52px;
+  padding: 52px 0 42px;
   width: fit-content;
 }
 
@@ -55,10 +55,34 @@
   .container {
     padding: 40px 24px;
   }
+
+  .content {
+    max-width: 720px;
+  }
+
+  .selectButton {
+    padding: 40px 0 28px;
+  }
 }
 
 @media screen and (max-width: 768px) {
   .container {
     padding: 40px 24px;
+  }
+
+  .content {
+    max-width: 320px;
+  }
+
+  .inputBox {
+    padding-bottom: 48px;
+  }
+
+  .selectButton {
+    padding: 24px 0 28px;
+  }
+
+  .createButton {
+    padding: 80px 0 24px;
   }
 }

--- a/src/component/pages/Post.module.css
+++ b/src/component/pages/Post.module.css
@@ -1,0 +1,59 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 60px 0 300px;
+}
+
+.content {
+  max-width: 1200px;
+}
+
+.inputBox {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  padding-bottom: 50px;
+}
+
+.inputName {
+  color: var(--gray-900);
+  font-size: var(--xxl);
+  font-weight: var(--bold);
+}
+
+.describeBackgroundInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.describeTitle {
+  color: var(--gray-900);
+  font-size: var(--xxl);
+  font-weight: var(--bold);
+}
+
+.describeSubtitle {
+  color: var(--gray-500);
+  font-size: var(--m);
+  font-weight: var(--regular);
+}
+
+.selectButton {
+  padding: 42px 0 52px;
+}
+
+
+@media screen and (min-width: 769px) and (max-width: 1024px) {
+  .container {
+    padding: 40px 24px;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .container {
+    padding: 40px 24px;
+  }
+}

--- a/src/component/pages/Post.module.css
+++ b/src/component/pages/Post.module.css
@@ -43,6 +43,7 @@
 
 .selectButton {
   padding: 42px 0 52px;
+  width: fit-content;
 }
 
 .createButton {

--- a/src/component/pages/Post.module.css
+++ b/src/component/pages/Post.module.css
@@ -45,6 +45,10 @@
   padding: 42px 0 52px;
 }
 
+.createButton {
+  padding: 70px 0;
+}
+
 
 @media screen and (min-width: 769px) and (max-width: 1024px) {
   .container {


### PR DESCRIPTION
- post 페이지에 필요한 컴포넌트를 배치하고 스타일을 입혔습니다.
- 생성하기 버튼을 넣는 것을 깜빡했습니다. 금방 다시 추가하겠습니다.(현재 추가되었습니다.)
- 컬러/이미지 토글을 클릭하면 해당 버튼에 맞는 option 컴포넌트가 뜨도록 구현했습니다.
- 생성하기 버튼을 누르면 /post/{id}로 잘 이동합니다.
- Tablet/Mobile 사이즈에 따른 반응형 디자인 적용했습니다.